### PR TITLE
feat: add pay invoice

### DIFF
--- a/bindings/una-js/index.d.ts
+++ b/bindings/una-js/index.d.ts
@@ -8,6 +8,7 @@ export class Node {
   constructor(backend: Backend, config: NodeConfig)
   createInvoice(invoice: CreateInvoiceParams): Promise<CreateInvoiceResult>
   getInfo(): Promise<NodeInfo>
+  payInvoice(invoice: PayInvoiceParams): Promise<PayInvoiceResult>
 }
 
 export type Backend = "LndRest" | "LndGrpc" | "ClnGrpc" | "EclairRest" | "InvalidBackend";
@@ -58,4 +59,19 @@ export interface NodeInfo {
   network: Network;
   node_pubkey: string;
   version: string;
+}
+
+export interface PayInvoiceParams {
+  amount?: number | null;
+  amount_msat?: number | null;
+  max_fee_msat?: number | null;
+  max_fee_percent?: number | null;
+  max_fee_sat?: number | null;
+  payment_request: string;
+}
+
+export interface PayInvoiceResult {
+  fees_msat?: number | null;
+  payment_hash: string;
+  payment_preimage: string;
 }

--- a/bindings/una-js/src/error.rs
+++ b/bindings/una-js/src/error.rs
@@ -29,12 +29,6 @@ impl From<NapiError> for Error {
     }
 }
 
-impl From<UnaError> for NapiError {
-    fn from(err: UnaError) -> Self {
-        NapiError(err)
-    }
-}
-
 pub trait OrNapiError<T> {
     fn or_napi_error(self) -> Result<T, NapiError>;
 }

--- a/bindings/una-js/test.mjs
+++ b/bindings/una-js/test.mjs
@@ -37,6 +37,7 @@ const invoice = {
 
 async function test_node(backend, config) {
   const node = new Node(backend, config);
+
   node
     .getInfo()
     .then((info) => console.log(info))
@@ -46,8 +47,16 @@ async function test_node(backend, config) {
     .createInvoice(invoice)
     .then((invoice) => console.log(invoice))
     .catch((err) => console.log(err.message, err.code));
+
+  node
+    .payInvoice({
+      payment_request:
+        "lnbcrt10u1p30ag67p5v45p0xljwcktszppfj8a3wcg460xrwwhpt0xcghx36xcsr3dkz7spp5nctfmzx6k5dyv693t52y0fs95zrk33f37mue5f3geu4wt9cwgltsdpz2phkcctjypykuan0d93k2grxdaezqcn0vgxqyjw5qcqp2rzjq25z6j80gkd8vyr5nptma4lnmhjvyq66eretzvy5a4gty72g8xpejqqqdsqqqqgqqyqqqqlgqqqqqqgq9q9qyysgqd4e22wy6ejggnpg8kfkuxf6vkgxejfe4283zjgsfxmd8w7dsvk7k43lsgakwzyanzfu372w8ke8tsuyzmp28kng4e6xyz8eyh99ncagpa8myt0",
+    })
+    .then((result) => console.log(result))
+    .catch((err) => console.log(err.message, err.code));
 }
 
 // test_node("LndRest", config.lnd.rest);
-// test_node("EclairRest", config.eclair.rest);
-test_node("ClnGrpc", config.cln.grpc);
+test_node("EclairRest", config.eclair.rest);
+// test_node("ClnGrpc", config.cln.grpc);

--- a/bindings/una-python/test.py
+++ b/bindings/una-python/test.py
@@ -16,6 +16,9 @@ async def lnd_rest():
     lnd_rest = una.Node("LndRest", config_lnd_rest)
     print(await lnd_rest.get_info())
     print(await lnd_rest.create_invoice(invoice))
+    print(await lnd_rest.pay_invoice(dict({
+        "payment_request": "lnbcrt10u1p306998pp53jzmkeummuu0u6rfxpcgx7rk5adturte8mppr64032nek3jmjtvqdq4w3jhxapqvf5kuerfdenhxcqzpgxqrrsssp53nhngg8858l2ch63ks3yc2uetzf4gnctp9xccqxuchztxmahd2as9qyyssqzl6m9rwgwp0r5a6de7fj98k42sn7vvf30n6k2ymcq7wvmk4689ls7zewqq9x5maqa60tshdmhu3gx3dd243vh9h9xralrfrjpfwfn3gq6xml7k"
+    })))
 
 async def cln_grpc():
     config_cln_grpc = dict({
@@ -28,6 +31,9 @@ async def cln_grpc():
     cln_grpc = una.Node("ClnGrpc", config_cln_grpc)
     print(await cln_grpc.get_info())
     print(await cln_grpc.create_invoice(invoice))
+    print(await cln_grpc.pay_invoice(dict({
+        "payment_request": "lnbcrt10u1p306998pp53jzmkeummuu0u6rfxpcgx7rk5adturte8mppr64032nek3jmjtvqdq4w3jhxapqvf5kuerfdenhxcqzpgxqrrsssp53nhngg8858l2ch63ks3yc2uetzf4gnctp9xccqxuchztxmahd2as9qyyssqzl6m9rwgwp0r5a6de7fj98k42sn7vvf30n6k2ymcq7wvmk4689ls7zewqq9x5maqa60tshdmhu3gx3dd243vh9h9xralrfrjpfwfn3gq6xml7k"
+    })))
 
 async def eclair_rest():
     config_eclair_rest = dict({
@@ -39,7 +45,10 @@ async def eclair_rest():
     eclair_rest = una.Node("EclairRest", config_eclair_rest)
     print(await eclair_rest.get_info())
     print(await eclair_rest.create_invoice(invoice))
+    print(await eclair_rest.pay_invoice(dict({
+        "payment_request": "lnbcrt10u1p30afdnsp5y05vz3g860fn8fy6fy2u9pr49ttnl6qq85v3mkmzz58cyqxmdpvspp52vy739gahycksqafupk4fw7mu0xjyf2l2e5exr64ycmjedzs3a5sdq4w3jhxapqvf5kuerfdenhxxqyjw5qcqp2rzjq25z6j80gkd8vyr5nptma4lnmhjvyq66eretzvy5a4gty72g8xpejqqqdsqqqqgqqyqqqqlgqqqqqqgq9q9qyysgqp0kpcx20yq5hftwguxfp0aka297g7kqplfl9ntc3rznkwnm9kf94ssq3qygjt2v0jrm95w2s590gc087vr6k3r9fvg9ey58et0dlcdcp978dh6"
+    })))
 
 # asyncio.run(lnd_rest())
-# asyncio.run(cln_grpc())
-asyncio.run(eclair_rest())
+asyncio.run(cln_grpc())
+# asyncio.run(eclair_rest())

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,6 +17,7 @@ tonic = { version = "0.8.0", features = ["tls"] }
 prost = "0.11"
 cuid = "1.2.0"
 http = "0.2.8"
+regex = "1.6.0"
 
 [build-dependencies]
 tonic-build = "0.8"

--- a/core/src/backends/cln/grpc/node.rs
+++ b/core/src/backends/cln/grpc/node.rs
@@ -2,7 +2,9 @@ use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint, Identity
 
 use crate::error::Error;
 use crate::node::NodeMethods;
-use crate::types::{CreateInvoiceParams, CreateInvoiceResult, NodeInfo};
+use crate::types::{
+    CreateInvoiceParams, CreateInvoiceResult, NodeInfo, PayInvoiceParams, PayInvoiceResult,
+};
 
 use super::config::ClnGrpcConfig;
 use super::pb::{node_client::NodeClient, GetinfoRequest, InvoiceRequest};
@@ -64,5 +66,9 @@ impl NodeMethods for ClnGrpc {
         result.label = Some(label);
 
         Ok(result)
+    }
+
+    async fn pay_invoice(&self, _invoice: PayInvoiceParams) -> Result<PayInvoiceResult, Error> {
+        Err(Error::NotImplemented)
     }
 }

--- a/core/src/backends/cln/grpc/node.rs
+++ b/core/src/backends/cln/grpc/node.rs
@@ -7,7 +7,7 @@ use crate::types::{
 };
 
 use super::config::ClnGrpcConfig;
-use super::pb::{node_client::NodeClient, GetinfoRequest, InvoiceRequest};
+use super::pb::{node_client::NodeClient, GetinfoRequest, InvoiceRequest, PayRequest};
 
 pub struct ClnGrpc {
     endpoint: Endpoint,
@@ -68,7 +68,12 @@ impl NodeMethods for ClnGrpc {
         Ok(result)
     }
 
-    async fn pay_invoice(&self, _invoice: PayInvoiceParams) -> Result<PayInvoiceResult, Error> {
-        Err(Error::NotImplemented)
+    async fn pay_invoice(&self, invoice: PayInvoiceParams) -> Result<PayInvoiceResult, Error> {
+        let mut client = self.get_client().await?;
+
+        let request: PayRequest = invoice.into();
+        let response = client.pay(request).await?.into_inner();
+
+        Ok(response.into())
     }
 }

--- a/core/src/backends/eclair/rest/node.rs
+++ b/core/src/backends/eclair/rest/node.rs
@@ -1,6 +1,8 @@
 use crate::error::Error;
 use crate::node::NodeMethods;
-use crate::types::{CreateInvoiceParams, CreateInvoiceResult, NodeInfo};
+use crate::types::{
+    CreateInvoiceParams, CreateInvoiceResult, NodeInfo, PayInvoiceParams, PayInvoiceResult,
+};
 
 use super::config::EclairRestConfig;
 use super::types::{
@@ -98,5 +100,9 @@ impl NodeMethods for EclairRest {
             .count() as i64;
 
         Ok(node_info)
+    }
+
+    async fn pay_invoice(&self, _invoice: PayInvoiceParams) -> Result<PayInvoiceResult, Error> {
+        Err(Error::NotImplemented)
     }
 }

--- a/core/src/backends/eclair/rest/types.rs
+++ b/core/src/backends/eclair/rest/types.rs
@@ -1,13 +1,15 @@
 #![allow(clippy::from_over_into)]
 
-use crate::types::*;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::error::Error;
+use crate::{types::*, utils};
 
 #[derive(Debug, Deserialize)]
 pub struct ApiError {
-    pub code: i32,
+    #[serde(rename = "error")]
     pub message: String,
-    pub details: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -82,19 +84,6 @@ pub enum ChannelState {
     Pending,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct Chain {
-    pub chain: String,
-    pub network: String,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct Feature {
-    pub name: String,
-    pub is_required: bool,
-    pub is_known: bool,
-}
-
 impl Into<NodeInfo> for GetInfoResponse {
     fn into(self) -> NodeInfo {
         let network = match self.network.as_ref() {
@@ -115,5 +104,167 @@ impl Into<NodeInfo> for GetInfoResponse {
                 pending: 0,
             },
         }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PayInvoiceRequest {
+    pub invoice: String,
+    pub amount_msat: Option<u64>,
+    pub max_attempts: Option<u64>,
+    pub max_fee_flat_sat: Option<u64>,
+    pub max_fee_pct: Option<u64>,
+    pub external_id: Option<String>,
+    pub path_finding_experiment_name: Option<String>,
+    pub blocking: bool,
+}
+
+impl From<PayInvoiceParams> for PayInvoiceRequest {
+    fn from(params: PayInvoiceParams) -> Self {
+        let amount_msat = utils::get_amount_msat(params.amount, params.amount_msat);
+        let max_fee_sat = utils::get_amount_msat(params.max_fee_sat, params.max_fee_msat);
+
+        PayInvoiceRequest {
+            invoice: params.payment_request,
+            amount_msat,
+            max_attempts: None,
+            max_fee_flat_sat: max_fee_sat,
+            max_fee_pct: params.max_fee_percent.map(|v| v as u64),
+            external_id: None,
+            path_finding_experiment_name: None,
+            blocking: true,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PayInvoiceResponse {
+    #[serde(rename = "type")]
+    pub type_field: String,
+    pub id: String,
+    pub payment_hash: String,
+    pub payment_preimage: Option<String>,
+    pub recipient_amount: Option<u64>,
+    pub recipient_node_id: Option<String>,
+    pub parts: Option<Vec<PaymentPart>>,
+    pub failures: Option<Vec<PaymentFailure>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PaymentPart {
+    pub id: String,
+    pub amount: i64,
+    pub fees_paid: i64,
+    pub to_channel_id: String,
+    pub route: Vec<Route>,
+    pub timestamp: Timestamp,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PaymentUpdate {
+    pub signature: String,
+    pub chain_hash: String,
+    pub short_channel_id: String,
+    pub timestamp: Timestamp,
+    pub channel_flags: ChannelFlags,
+    pub cltv_expiry_delta: i64,
+    pub htlc_minimum_msat: i64,
+    pub fee_base_msat: i64,
+    pub fee_proportional_millionths: i64,
+    pub htlc_maximum_msat: i64,
+    pub tlv_stream: TlvStream,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Route {
+    pub node_id: String,
+    pub next_node_id: String,
+    pub last_update: PaymentUpdate,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TlvStream {
+    pub records: Vec<Value>,
+    pub unknown: Vec<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+
+pub struct ChannelFlags {
+    pub is_enabled: bool,
+    pub is_node1: bool,
+}
+
+#[derive(Debug, Deserialize)]
+
+pub struct Timestamp {
+    pub iso: String,
+    pub unix: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PaymentFailure {
+    pub amount: i64,
+    pub route: Vec<Route>,
+    #[serde(rename = "e")]
+    pub route_error: Option<RouteError>,
+    #[serde(rename = "t")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RouteError {
+    pub origin_node: String,
+    pub failure_message: String,
+}
+
+impl TryInto<PayInvoiceResult> for PayInvoiceResponse {
+    type Error = Error;
+
+    fn try_into(self) -> Result<PayInvoiceResult, Self::Error> {
+        if self.type_field.as_str() == "payment-failed" {
+            let failures = self.failures.ok_or_else(|| {
+                Error::ApiError(String::from(
+                    "error paying invoice, couldn't extract error message",
+                ))
+            })?;
+            let failure = failures.first().ok_or_else(|| {
+                Error::ApiError(String::from(
+                    "error paying invoice, couldn't extract error message",
+                ))
+            })?;
+
+            return match (&failure.route_error, &failure.error) {
+                (Some(err), _) => Err(Error::ApiError(err.failure_message.to_string())),
+                (_, Some(err)) => Err(Error::ApiError(err.to_string())),
+                _ => Err(Error::ApiError(String::from(
+                    "error paying invoice, couldn't extract error message",
+                ))),
+            };
+        }
+
+        let fees_msat = self.parts.map(|parts| {
+            parts
+                .iter()
+                .fold(0, |acc, part| acc + part.fees_paid as u64)
+        });
+
+        let result = PayInvoiceResult {
+            payment_hash: self.payment_hash,
+            payment_preimage: self.payment_preimage.ok_or_else(|| {
+                Error::ApiError(String::from("invoice paid but missing preimage"))
+            })?,
+            fees_msat,
+        };
+
+        Ok(result)
     }
 }

--- a/core/src/backends/lnd/rest/node.rs
+++ b/core/src/backends/lnd/rest/node.rs
@@ -1,6 +1,8 @@
 use crate::error::Error;
 use crate::node::NodeMethods;
-use crate::types::{CreateInvoiceParams, CreateInvoiceResult, NodeInfo};
+use crate::types::{
+    CreateInvoiceParams, CreateInvoiceResult, NodeInfo, PayInvoiceParams, PayInvoiceResult,
+};
 
 use super::config::LndRestConfig;
 use super::types::{ApiError, CreateInvoiceRequest, CreateInvoiceResponse, GetInfoResponse};
@@ -77,5 +79,9 @@ impl NodeMethods for LndRest {
         let data: GetInfoResponse = response.json().await?;
 
         Ok(data.into())
+    }
+
+    async fn pay_invoice(&self, _invoice: PayInvoiceParams) -> Result<PayInvoiceResult, Error> {
+        Err(Error::NotImplemented)
     }
 }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -105,6 +105,12 @@ impl From<base64::DecodeError> for Error {
     }
 }
 
+impl From<std::num::ParseIntError> for Error {
+    fn from(_: std::num::ParseIntError) -> Self {
+        Error::ConversionError(String::from("couldn't convert string to integer"))
+    }
+}
+
 impl From<Error> for std::io::Error {
     fn from(e: Error) -> std::io::Error {
         std::io::Error::new(ErrorKind::Other, e.to_string())

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -77,7 +77,7 @@ impl From<reqwest::Error> for Error {
 
 impl From<tonic::transport::Error> for Error {
     fn from(err: tonic::transport::Error) -> Self {
-        Error::ApiError(err.to_string())
+        Error::ConnectionError(err.to_string())
     }
 }
 
@@ -89,7 +89,23 @@ impl From<reqwest::header::InvalidHeaderValue> for Error {
 
 impl From<tonic::Status> for Error {
     fn from(status: tonic::Status) -> Self {
-        Error::ApiError(status.message().to_string())
+        let status_message = status.message().to_string();
+
+        let rpc_error_regex =
+            regex::Regex::new(r"RpcError").expect("Hardcoded regex should be valid.");
+        if rpc_error_regex.is_match(&status_message) {
+            let rpc_error_message_regex = regex::Regex::new(r#"message: "(?P<msg>.*)""#)
+                .expect("Hardcoded regex should be valid.");
+            let rpc_error_message = rpc_error_message_regex
+                .captures(&status_message)
+                .and_then(|cap| cap.name("msg").map(|msg| msg.as_str()));
+
+            if let Some(message) = rpc_error_message {
+                return Error::ApiError(message.to_string());
+            }
+        }
+
+        Error::ApiError(status_message)
     }
 }
 

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -99,6 +99,12 @@ impl From<ConfigError> for Error {
     }
 }
 
+impl From<base64::DecodeError> for Error {
+    fn from(_: base64::DecodeError) -> Self {
+        Error::ConversionError(String::from("couldn't convert base64 to hex"))
+    }
+}
+
 impl From<Error> for std::io::Error {
     fn from(e: Error) -> std::io::Error {
         std::io::Error::new(ErrorKind::Other, e.to_string())

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -2,3 +2,4 @@ pub mod backends;
 pub mod error;
 pub mod node;
 pub mod types;
+pub mod utils;

--- a/core/src/node.rs
+++ b/core/src/node.rs
@@ -2,7 +2,10 @@ use crate::backends::cln::grpc::node::ClnGrpc;
 use crate::backends::eclair::rest::node::EclairRest;
 use crate::backends::lnd::rest::node::LndRest;
 use crate::error::Error;
-use crate::types::{Backend, CreateInvoiceParams, CreateInvoiceResult, NodeConfig, NodeInfo};
+use crate::types::{
+    Backend, CreateInvoiceParams, CreateInvoiceResult, NodeConfig, NodeInfo, PayInvoiceParams,
+    PayInvoiceResult,
+};
 
 #[async_trait::async_trait]
 pub trait NodeMethods {
@@ -11,6 +14,7 @@ pub trait NodeMethods {
         invoice: CreateInvoiceParams,
     ) -> Result<CreateInvoiceResult, Error>;
     async fn get_info(&self) -> Result<NodeInfo, Error>;
+    async fn pay_invoice(&self, invoice: PayInvoiceParams) -> Result<PayInvoiceResult, Error>;
 }
 
 pub struct Node {
@@ -58,5 +62,9 @@ impl NodeMethods for Node {
 
     async fn get_info(&self) -> Result<NodeInfo, Error> {
         self.node.get_info().await
+    }
+
+    async fn pay_invoice(&self, invoice: PayInvoiceParams) -> Result<PayInvoiceResult, Error> {
+        self.node.pay_invoice(invoice).await
     }
 }

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -116,3 +116,20 @@ pub struct NodeInfo {
     pub node_pubkey: String,
     pub channels: ChannelStats,
 }
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct PayInvoiceParams {
+    pub payment_request: String,
+    pub amount: Option<u64>,
+    pub amount_msat: Option<u64>,
+    pub max_fee_sat: Option<u64>,
+    pub max_fee_msat: Option<u64>,
+    pub max_fee_percent: Option<f64>,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct PayInvoiceResult {
+    pub payment_hash: String,
+    pub payment_preimage: String,
+    pub fees_msat: Option<u64>,
+}

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -1,0 +1,44 @@
+use std::ops::{Div, Mul};
+
+use crate::error::Error;
+
+pub fn sat_to_msat<T>(sat: T) -> T
+where
+    T: Mul<u64, Output = T>,
+{
+    sat * 1_000
+}
+
+pub fn msat_to_sat<T>(msat: T) -> T
+where
+    T: Div<u64, Output = T>,
+{
+    msat / 1_000
+}
+
+pub fn get_amount_msat<T>(sat: Option<T>, msat: Option<T>) -> Option<T>
+where
+    T: Mul<u64, Output = T> + Div<u64, Output = T>,
+{
+    match (sat, msat) {
+        (Some(sat), _) => Some(sat_to_msat(sat)),
+        (_, Some(msat)) => Some(msat),
+        (None, None) => None,
+    }
+}
+
+pub fn get_amount_sat<T>(sat: Option<T>, msat: Option<T>) -> Option<T>
+where
+    T: Mul<u64, Output = T> + Div<u64, Output = T>,
+{
+    match (sat, msat) {
+        (Some(sat), _) => Some(sat),
+        (_, Some(msat)) => Some(msat_to_sat(msat)),
+        (None, None) => None,
+    }
+}
+
+pub fn b64_to_hex(b64: &str) -> Result<String, Error> {
+    let bytes = base64::decode(b64)?;
+    Ok(hex::encode(&bytes))
+}

--- a/schemas/src/main.rs
+++ b/schemas/src/main.rs
@@ -3,6 +3,7 @@ use std::env;
 
 use una_core::types::{
     Backend, ChannelStats, CreateInvoiceParams, CreateInvoiceResult, Network, NodeConfig, NodeInfo,
+    PayInvoiceParams, PayInvoiceResult,
 };
 
 fn write_schema(dir: &std::path::Path, name: &str, schema: &RootSchema) -> std::io::Result<()> {
@@ -40,6 +41,12 @@ fn main() {
 
     let schema = schema_for!(CreateInvoiceResult);
     write_schema(&dir, "create_invoice_result", &schema).unwrap();
+
+    let schema = schema_for!(PayInvoiceParams);
+    write_schema(&dir, "pay_invoice_params", &schema).unwrap();
+
+    let schema = schema_for!(PayInvoiceResult);
+    write_schema(&dir, "pay_invoice_result", &schema).unwrap();
 
     println!("Wrote schemas to {}", dir.to_string_lossy());
 }


### PR DESCRIPTION
This PR adds a new `Node` method to pay a provided invoice. Input and output types are open to discussion.

**Input**
```rust
invoice: PayInvoiceParams

pub struct PayInvoiceParams {
    pub payment_request: String,
    pub amount: Option<u64>,
    pub amount_msat: Option<u64>,
    // the following fields represent the maximum fees we are willing to pay for sending this payment
    pub max_fee_sat: Option<u64>,
    pub max_fee_msat: Option<u64>,
    pub max_fee_percent: Option<f64>,
}
```
Output
```rust
pub struct PayInvoiceResult {
    pub payment_hash: String,
    pub payment_preimage: String,
    pub fees_msat: Option<u64>, // total fees paid in millisatoshi
}
```

Closes #16.