### PR TITLE
feat(una-python): use limited API abi3 to support more versions

### DIFF
--- a/bindings/una-python/Cargo.toml
+++ b/bindings/una-python/Cargo.toml
@@ -8,7 +8,7 @@ name = "una"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.16", features = ["extension-module"] }
+pyo3 = { version = "0.16", features = ["extension-module", "abi3-py37"] }
 pyo3-asyncio = { version = "0.16", features = ["tokio-runtime"] }
 tokio = "1.9"
 pythonize = "0.16.0"

--- a/bindings/una-python/README.md
+++ b/bindings/una-python/README.md
@@ -1,14 +1,16 @@
 # Python bindings for UNA
 
+Requires Python >=3.7.
+
 ## Build
 
 ### Setup environment
 
 ```shell
 $ cd bindings/una-python
-$ python -m venv venv
-$ source venv/bin/activate
-$ pip install maturin
+$ python -m venv .venv
+$ source .venv/bin/activate
+$ pip install -U pip maturin
 ```
 
 ### Build the package


### PR DESCRIPTION
By default, Python extension modules can only be used with the same Python version they were compiled against. For example, an extension module built for Python 3.5 can't be imported in Python 3.8. PEP 384 introduced the idea of the limited Python API, which would have a stable ABI enabling extension modules built with it to be used against multiple Python versions. This is also known as abi3.

See https://pyo3.rs/latest/building_and_distribution.html#py_limited_apiabi3.
