### PR TITLE
feat: custom proto builder separated from main package build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 /Cargo.lock
 /.DS_Store
+/proto/out/*
+!/proto/out/.gitkeep

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [workspace]
-members = [".", "core","bindings/una-python","bindings/una-js","schemas"]
+members = [".", "core","bindings/una-python","bindings/una-js","schemas","proto-builder"]
 
 [[bin]]
 name = "una-cli"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,6 +18,3 @@ prost = "0.11"
 cuid = "1.2.0"
 http = "0.2.8"
 regex = "1.6.0"
-
-[build-dependencies]
-tonic-build = "0.8"

--- a/core/build.rs
+++ b/core/build.rs
@@ -1,4 +1,7 @@
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("../proto/cln-v0.11.2/node.proto")?;
-    Ok(())
+use std::path::Path;
+
+fn main() {
+    let cargo_workspace_dir = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+
+    println!("cargo:rustc-env=PROTOBUFS_DIR={}", Path::new(&cargo_workspace_dir).join("proto/out").display());
 }

--- a/core/src/backends/cln/grpc/pb.rs
+++ b/core/src/backends/cln/grpc/pb.rs
@@ -3,7 +3,7 @@
 use crate::{types::*, utils};
 use cuid;
 
-tonic::include_proto!("cln");
+include!(concat!(env!("PROTOBUFS_DIR"), "/cln.rs"));
 
 impl From<CreateInvoiceParams> for InvoiceRequest {
     fn from(params: CreateInvoiceParams) -> Self {

--- a/proto-builder/Cargo.toml
+++ b/proto-builder/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "una-proto-builder"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tonic = { version = "0.8.0", features = ["tls"] }
+prost = "0.11"
+tonic-build = "0.8"

--- a/proto-builder/src/main.rs
+++ b/proto-builder/src/main.rs
@@ -1,0 +1,16 @@
+use std::path::Path;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cargo_workspace_dir = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+
+    std::env::set_var("OUT_DIR", Path::new(&cargo_workspace_dir).join("proto/out"));
+
+    tonic_build::configure()
+        .build_server(false)
+        .compile(
+            &[Path::new(&cargo_workspace_dir).join("proto/cln-v0.11.2/node.proto")],
+            &[Path::new(&cargo_workspace_dir).join("proto/cln-v0.11.2")],
+        )?;
+
+    Ok(())
+}


### PR DESCRIPTION
This PR introduces a new `proto-builder` package, used to manually build Rust files from Protobufs. We need to 
register manually the paths to the Protobuf files to build in `proto-builder/main.rs`. 
https://github.com/blc-org/una/blob/478cbb7c2ec7da19ce7b8639a4fa83f70374f0b5/proto-builder/src/main.rs#L8-L13
Then, running the package binary (using for example `cargo run --package una-proto-builder` from the project root) will automatically build the Protobuf files to `proto/out`.

The resulting compiled files can then be included in an existing Rust file with the following instruction 
(example for `cln.rs`):
```rust
include!(concat!(env!("PROTOBUFS_DIR"), "/cln.rs"));
``` 

This was mainly needed for the good execution of our CI workflows, but in retrospective it is also better to keep 
a deterministic compiled version in the repo (to keep track of changes, or just be able to lookup the 
compiled Rust types without going through the target directory`. 
