### PR TITLE
Fix purging of cancelled invoices

### DIFF
--- a/src/backends/lnd-rest/i-invoice.ts
+++ b/src/backends/lnd-rest/i-invoice.ts
@@ -1,4 +1,4 @@
-export interface ILndInvoice {
+export interface ILndInvoice extends ILndResponse {
   memo: string
   r_preimage: string
   r_hash: string
@@ -24,6 +24,12 @@ export interface ILndInvoice {
   features: { [key: string]: IFeature }
   is_keysend: boolean
   payment_addr: string
+}
+
+interface ILndResponse {
+  code: number
+  message: string
+  details: any[]
 }
 
 interface IFeature {

--- a/src/backends/lnd-rest/lnd-rest.ts
+++ b/src/backends/lnd-rest/lnd-rest.ts
@@ -38,6 +38,10 @@ export default class LndRest extends Backend {
     const options = this.getRequestOptions(EHttpVerb.GET, '/v1/invoice/' + hash)
     const response = await this.request(options) as ILndInvoice
 
+    // With certain LND configurations, invoices are purged immediately on expiry
+    // https://github.com/lightningnetwork/lnd/issues/6299
+    if (response.code) return Promise.reject(new Error(response.message)) 
+
     return this.toInvoice(response)
   }
 


### PR DESCRIPTION
Fix a bug in purging of settled invoices on the LND REST API backend. This caused future pending invoice queries to fail because the internal administration no longer aligned with the LND pending invoices and caused the invoice watch to fail.